### PR TITLE
Update functions.py to update correct version number in banner

### DIFF
--- a/dscan/common/functions.py
+++ b/dscan/common/functions.py
@@ -214,7 +214,7 @@ def version_get():
     Returns current droopescan version. Not. It was broken and not a useful
     feature, so I replaced it with a way more elite version.
     """
-    version = '1.33.7'
+    version = '1.45.1'
     return version
 
 def error(msg):


### PR DESCRIPTION
Version number was showing wrong, 1.33.7

![image](https://user-images.githubusercontent.com/16804210/230536143-4b3638d2-7969-4cdb-a620-a25ec92b3d16.png)

Corrected version number, 1.45.1

![image](https://user-images.githubusercontent.com/16804210/230536232-fcf9af08-b905-454d-b480-d0a84dec3c5a.png)

